### PR TITLE
Add -S,--make-all-lts flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Available options:
                            Set stack.yaml resolver
   -u,--update-resolver     Update stack.yaml resolver
   -s,--make-lts MAJOR      Create a stack-ltsXX.yaml file
+  -S,--make-all-lts        Create all stack-ltsXX.yaml files
 ```
 
 ### Overriding stack.yaml


### PR DESCRIPTION
This is equivalent to calling `-s` repeatedly for each (configured) LTS,
generating all `stack-ltsXX.yaml` files at once.

We also respect `--keep-going`, such that the command can be used to
generate only those configs that are missing, instead of erroring out on
the first one that isn't.
